### PR TITLE
Add float types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: build
       run: cd build && make
     - name: test
-      run: cd .. && ctest --output-on-failure
+      run: ctest --output-on-failure
     - name: package
       run: cd build && make package
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
       run: mkdir build && cd build && cmake -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_BUILD_TYPE=Release ..
     - name: build
       run: cd build && make
+    - name: test
+      run: cd .. && ctest --output-on-failure
     - name: package
       run: cd build && make package
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: build
       run: cd build && make
     - name: test
-      run: ctest --output-on-failure
+      run: cd build && ctest --output-on-failure
     - name: package
       run: cd build && make package
     - uses: actions/upload-artifact@v2

--- a/libs/loaders/src/llvm/context.cpp
+++ b/libs/loaders/src/llvm/context.cpp
@@ -41,6 +41,12 @@ namespace MiniMC {
         return MiniMC::Model::TypeID::Struct;
       }
 
+      else if (type->isFloatTy()) {
+        return MiniMC::Model::TypeID::Float;
+      } else if (type->isDoubleTy()) {
+        return MiniMC::Model::TypeID::Double;
+      }
+
       else if (type->isArrayTy()) {
         return MiniMC::Model::TypeID::Array;
       }

--- a/libs/loaders/src/llvm/context.cpp
+++ b/libs/loaders/src/llvm/context.cpp
@@ -55,37 +55,37 @@ namespace MiniMC {
     }
 
     MiniMC::Model::Type_ptr GLoadContext::getType (llvm::Type* type ) {
-    
+
       auto type_id = getTypeID (type); 
       switch  (type_id) {
-      case MiniMC::Model::TypeID::Bool:
-	return tfact.makeBoolType ();
-      case MiniMC::Model::TypeID::I8:
-	return tfact.makeIntegerType (8);
-      case MiniMC::Model::TypeID::I16:
-	return tfact.makeIntegerType (16);
-      case MiniMC::Model::TypeID::I32:
-	return tfact.makeIntegerType (32);
-      case MiniMC::Model::TypeID::I64:
-	return tfact.makeIntegerType (64);
-      case MiniMC::Model::TypeID::Pointer:
-	return tfact.makePointerType ();
-      case MiniMC::Model::TypeID::Array:
-	return tfact.makeArrayType (computeSizeInBytes (type));
-      case MiniMC::Model::TypeID::Struct:
-	return tfact.makeStructType (computeSizeInBytes (type));
-      case MiniMC::Model::TypeID::Void:
-	  return tfact.makeVoidType ();
-      case MiniMC::Model::TypeID::Float:
-	  return tfact.makeFloatType ();
-      case MiniMC::Model::TypeID::Double:
-	  return tfact.makeDoubleType ();
-	  
-      default:
-	throw MiniMC::Support::Exception ("Unsupported type");
+        case MiniMC::Model::TypeID::Bool:
+          return tfact.makeBoolType ();
+        case MiniMC::Model::TypeID::I8:
+          return tfact.makeIntegerType (8);
+        case MiniMC::Model::TypeID::I16:
+          return tfact.makeIntegerType (16);
+        case MiniMC::Model::TypeID::I32:
+          return tfact.makeIntegerType (32);
+        case MiniMC::Model::TypeID::I64:
+          return tfact.makeIntegerType (64);
+        case MiniMC::Model::TypeID::Pointer:
+          return tfact.makePointerType ();
+        case MiniMC::Model::TypeID::Array:
+          return tfact.makeArrayType (computeSizeInBytes (type));
+        case MiniMC::Model::TypeID::Struct:
+          return tfact.makeStructType (computeSizeInBytes (type));
+        case MiniMC::Model::TypeID::Void:
+          return tfact.makeVoidType ();
+        case MiniMC::Model::TypeID::Float:
+          return tfact.makeFloatType ();
+        case MiniMC::Model::TypeID::Double:
+          return tfact.makeDoubleType ();
+
+        default:
+          throw MiniMC::Support::Exception ("Unsupported type");
       }
     }
-    
+
     MiniMC::BV32 GLoadContext::computeSizeInBytes (llvm::Type* ty ) {
       if (ty->isArrayTy()) {
         return ty->getArrayNumElements() * computeSizeInBytes(ty->getArrayElementType());
@@ -101,14 +101,20 @@ namespace MiniMC {
       }
 
       else if (ty->isIntegerTy ()) {
-	return tfact.makeIntegerType (ty->getIntegerBitWidth())->getSize ();
+        return tfact.makeIntegerType (ty->getIntegerBitWidth())->getSize ();
       }
       else if (ty->isPointerTy ()) {
-	return tfact.makePointerType ()->getSize ();
+        return tfact.makePointerType ()->getSize ();
+      }
+      else if (ty->isFloatTy ()) {
+        return tfact.makeFloatType ()->getSize ();
+      }
+      else if (ty->isDoubleTy ()) {
+        return tfact.makeDoubleType ()->getSize ();
       }
       throw MiniMC::Support::Exception("Can't calculate size of type");
     }
-    
+
     MiniMC::Model::Value_ptr GLoadContext::findValue(const llvm::Value* val) {
       auto constant = llvm::dyn_cast<llvm::Constant>(val);
       if (constant) {
@@ -124,6 +130,13 @@ namespace MiniMC {
           if (csti) {
             auto type = getTypeID(csti->getType());
             auto cst = cfact.makeIntegerConstant(csti->getZExtValue(), type);
+            return cst;
+          }
+        } else if (ltype->isFloatTy() || ltype->isDoubleTy()) {
+          const llvm::ConstantFP* cstf = llvm::dyn_cast<const llvm::ConstantFP>(constant);
+          if (cstf) {
+            auto type = getTypeID(cstf->getType());
+            auto cst = cfact.makeFloatConstant(cstf->getValueAPF().convertToDouble(), type);
             return cst;
           }
         } else if (ltype->isStructTy() || ltype->isArrayTy()) {
@@ -157,7 +170,7 @@ namespace MiniMC {
           // assert(false && "FAil");
 
         } else if (llvm::isa<llvm::Function>(val) ||
-                   llvm::isa<llvm::GlobalVariable>(val)) {
+            llvm::isa<llvm::GlobalVariable>(val)) {
           return values.at(val);
         } else if (const llvm::BlockAddress* block = llvm::dyn_cast<const llvm::BlockAddress>(val)) {
           return values.at(block->getBasicBlock());
@@ -176,10 +189,10 @@ namespace MiniMC {
       }
 
       else {
-	return values.at (val);
+        return values.at (val);
       }
     }
-    
-     
+
+
   } // namespace Loaders
 } // namespace MiniMC

--- a/libs/model/include/model/types.hpp
+++ b/libs/model/include/model/types.hpp
@@ -54,6 +54,37 @@ namespace MiniMC {
       virtual std::size_t getSize() const = 0;
 
       TypeID getTypeID() const { return id; }
+
+      std::string get_type_name() const {
+        switch (id) {
+          case TypeID::Bool:
+            return "bool";
+          case TypeID::I8:
+            return "i8";
+          case TypeID::I16:
+            return "i16";
+          case TypeID::I32:
+            return "i32";
+          case TypeID::I64:
+            return "i64";
+          case TypeID::Float:
+            return "float";
+          case TypeID::Double:
+            return "double";
+          case TypeID::Pointer:
+            return "pointer";
+          case TypeID::Pointer32:
+            return "pointer32";
+          case TypeID::Struct:
+            return "struct";
+          case TypeID::Array:
+            return "array";
+          case TypeID::Void:
+            return "void";
+          default:
+            return "unknown";
+        }
+      }
       
       virtual bool isEqual(const Type& t) {
         return (&t == this) ||

--- a/libs/model/include/model/types.hpp
+++ b/libs/model/include/model/types.hpp
@@ -61,6 +61,8 @@ namespace MiniMC {
       }
       
       virtual bool isInteger () const {return false;}
+      virtual bool isFloat () const {return false;}
+      virtual bool isDouble () const {return false;}
       virtual bool isAggregate () const {return false;}
       
     protected:

--- a/libs/model/include/model/variables.hpp
+++ b/libs/model/include/model/variables.hpp
@@ -262,6 +262,7 @@ namespace MiniMC {
       using aggr_input = std::vector<Constant_ptr>;
       virtual const Value_ptr makeAggregateConstant(const aggr_input& inp, bool) = 0;
       virtual const Value_ptr makeIntegerConstant(MiniMC::BV64, TypeID) = 0;
+      virtual const Value_ptr makeFloatConstant(MiniMC::BV64, TypeID) = 0;
       virtual const Value_ptr makeFunctionPointer(MiniMC::func_t) = 0;
       virtual const Value_ptr makeHeapPointer(MiniMC::base_t) = 0;
       
@@ -276,6 +277,7 @@ namespace MiniMC {
       ConstantFactory64(TypeFactory_ptr tfac) : ConstantFactory(tfac) {}
       virtual ~ConstantFactory64() {}
       virtual const Value_ptr makeIntegerConstant(MiniMC::BV64, TypeID);
+      virtual const Value_ptr makeFloatConstant(MiniMC::BV64, TypeID);
       virtual const Value_ptr makeAggregateConstant(const aggr_input& inp, bool);
       virtual const Value_ptr makeFunctionPointer(MiniMC::func_t);
       virtual const Value_ptr makeLocationPointer(MiniMC::func_t, MiniMC::base_t);

--- a/libs/model/src/checkers/typechecker/typechecker.cpp
+++ b/libs/model/src/checkers/typechecker/typechecker.cpp
@@ -8,443 +8,445 @@ namespace MiniMC {
   namespace Model {
     namespace Checkers {
       template <MiniMC::Model::InstructionCode i>
-      bool doCheck(MiniMC::Model::Instruction& inst, const MiniMC::Model::Type_ptr& tt, MiniMC::Model::Program& prgm) {
-	MiniMC::Support::Messager mess;
-        auto& content = inst.getOps<i>();
-        if constexpr (InstructionData<i>::isTAC ||  i  == MiniMC::Model::InstructionCode::PtrEq) {
-          MiniMC::Support::Localiser loc("All operands to '%1%' must have same type as the result.");
-          auto resType = content.res->getType();
-          auto lType = content.op1->getType();
-          auto rType = content.op2->getType();
-          if (resType != lType ||
-              lType != rType ||
-              rType != resType) {
-            mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
-            return false;
-          }
-          return true;
-        } else if constexpr (InstructionData<i>::isPredicate) {
-          MiniMC::Support::Localiser loc("All operands to '%1%' must be same type.");
-          auto lType = content.op1->getType();
-          auto rType = content.op2->getType();
-          if (lType != rType) {
-            mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
-            return false;
-          }
-          return true;
-        }
-
-        else if constexpr (InstructionData<i>::isUnary) {
-          if constexpr (i == MiniMC::Model::InstructionCode::Not) {
+        bool doCheck(MiniMC::Model::Instruction& inst, const MiniMC::Model::Type_ptr& tt, MiniMC::Model::Program& prgm) {
+          MiniMC::Support::Messager mess;
+          auto& content = inst.getOps<i>();
+          if constexpr (InstructionData<i>::isTAC ||  i  == MiniMC::Model::InstructionCode::PtrEq) {
             MiniMC::Support::Localiser loc("All operands to '%1%' must have same type as the result.");
             auto resType = content.res->getType();
             auto lType = content.op1->getType();
-            if (resType != lType) {
+            auto rType = content.op2->getType();
+            if (resType != lType ||
+                lType != rType ||
+                rType != resType) {
+              mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
+              return false;
+            }
+            return true;
+          } else if constexpr (InstructionData<i>::isPredicate) {
+            MiniMC::Support::Localiser loc("All operands to '%1%' must be same type.");
+            auto lType = content.op1->getType();
+            auto rType = content.op2->getType();
+            if (lType != rType) {
               mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
               return false;
             }
             return true;
           }
-        }
 
-        else if constexpr (InstructionData<i>::isComparison) {
-          MiniMC::Support::Localiser loc("All operands to '%1%' must have same type..");
-          MiniMC::Support::Localiser res_must_be_bool("The result of '%1% must be boolean.");
-
-          auto resType = content.res->getType();
-          auto lType = content.op1->getType();
-          auto rType = content.op2->getType();
-          if (lType != rType) {
-            mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
-            return false;
-          } else if (resType->getTypeID() != MiniMC::Model::TypeID::Bool) {
-            mess.message<MiniMC::Support::Severity::Error>(res_must_be_bool.format(i));
-            return false;
+          else if constexpr (InstructionData<i>::isUnary) {
+            if constexpr (i == MiniMC::Model::InstructionCode::Not) {
+              MiniMC::Support::Localiser loc("All operands to '%1%' must have same type as the result.");
+              auto resType = content.res->getType();
+              auto lType = content.op1->getType();
+              if (resType != lType) {
+                mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
+                return false;
+              }
+              return true;
+            }
           }
 
-          return true;
-        }
+          else if constexpr (InstructionData<i>::isComparison) {
+            MiniMC::Support::Localiser loc("All operands to '%1%' must have same type..");
+            MiniMC::Support::Localiser res_must_be_bool("The result of '%1% must be boolean.");
 
-        else if constexpr (i == InstructionCode::Trunc) {
-          MiniMC::Support::Localiser trunc_must_be_integer("'%1%' can only be applied to integer types. ");
-          MiniMC::Support::Localiser trunc_must_be_larger("From type must be larger that to type for '%1%'");
+            auto resType = content.res->getType();
+            auto lType = content.op1->getType();
+            auto rType = content.op2->getType();
+            if (lType != rType) {
+              mess.message<MiniMC::Support::Severity::Error>(loc.format(i));
+              return false;
+            } else if (resType->getTypeID() != MiniMC::Model::TypeID::Bool) {
+              mess.message<MiniMC::Support::Severity::Error>(res_must_be_bool.format(i));
+              return false;
+            }
 
-          auto ftype = content.op1->getType();
-          auto ttype = content.res->getType();
-          if (!ftype->isInteger () ||
-              !ttype->isInteger () ) {
-            mess.message<MiniMC::Support::Severity::Error>(trunc_must_be_integer.format(MiniMC::Model::InstructionCode::Trunc));
-            return false;
-          } else if (ftype->getSize() <= ttype->getSize()) {
-            mess.message<MiniMC::Support::Severity::Error>(trunc_must_be_larger.format(MiniMC::Model::InstructionCode::Trunc));
-            return false;
+            return true;
           }
 
-          return true;
-        }
+          else if constexpr (i == InstructionCode::Trunc) {
+            MiniMC::Support::Localiser trunc_must_be_integer("'%1%' can only be applied to integer types. ");
+            MiniMC::Support::Localiser trunc_must_be_larger("From type must be larger that to type for '%1%'");
 
-        else if constexpr (i == InstructionCode::IntToBool) {
-          MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied to integer types. ");
-          MiniMC::Support::Localiser must_be_smaller("From type must be smaller that to type for '%1%'");
+            auto ftype = content.op1->getType();
+            auto ttype = content.res->getType();
+            if (!ftype->isInteger () ||
+                !ttype->isInteger () ) {
+              mess.message<MiniMC::Support::Severity::Error>(trunc_must_be_integer.format(MiniMC::Model::InstructionCode::Trunc));
+              return false;
+            } else if (ftype->getSize() <= ttype->getSize()) {
+              mess.message<MiniMC::Support::Severity::Error>(trunc_must_be_larger.format(MiniMC::Model::InstructionCode::Trunc));
+              return false;
+            }
 
-          auto ftype = content.op1->getType();
-          auto ttype = content.res->getType();
-
-          if (!ftype->isInteger () ||
-              ttype->getTypeID() != MiniMC::Model::TypeID::Bool) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::IntToBool));
-            return false;
-          }
-          return true;
-        }
-
-        else if constexpr (i == InstructionCode::SExt ||
-                           i == InstructionCode::ZExt) {
-          MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied to integer types. ");
-          MiniMC::Support::Localiser must_be_smaller("From type must be smaller that to type for '%1%'");
-
-          auto ftype = content.op1->getType();
-          auto ttype = content.res->getType();
-
-          if (!ftype->isInteger () ||
-              !ttype->isInteger () ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
-            return false;
-          } else if (ftype->getSize() > ttype->getSize()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_smaller.format(i));
-            return false;
+            return true;
           }
 
-          return true;
-        }
+          else if constexpr (i == InstructionCode::IntToBool) {
+            MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied to integer types. ");
+            MiniMC::Support::Localiser must_be_smaller("From type must be smaller that to type for '%1%'");
 
-        else if constexpr (i == InstructionCode::BoolSExt ||
-                           i == InstructionCode::BoolZExt) {
+            auto ftype = content.op1->getType();
+            auto ttype = content.res->getType();
 
-          MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied from boolean types to  integer types. ");
-          MiniMC::Support::Localiser must_be_smaller("From type must be smaller that to type for '%1%'");
-
-          auto ftype = content.op1->getType();
-          auto ttype = content.res->getType();
-
-          if (ftype->getTypeID() != MiniMC::Model::TypeID::Bool ||
-              !ttype->isInteger () ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
-            return false;
-          } else if (ftype->getSize() > ttype->getSize()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_smaller.format(i));
-            return false;
+            if (!ftype->isInteger () ||
+                ttype->getTypeID() != MiniMC::Model::TypeID::Bool) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::IntToBool));
+              return false;
+            }
+            return true;
           }
 
-          return true;
-        }
+          else if constexpr (i == InstructionCode::SExt ||
+              i == InstructionCode::ZExt) {
+            MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied to integer types. ");
+            MiniMC::Support::Localiser must_be_smaller("From type must be smaller that to type for '%1%'");
 
-        else if constexpr (i == InstructionCode::IntToPtr) {
-          MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied to integer types. ");
-          MiniMC::Support::Localiser must_be_pointer("Return type has to be pointer for '%1%'");
+            auto ftype = content.op1->getType();
+            auto ttype = content.res->getType();
 
-          auto ftype = content.op1->getType();
-          auto ttype = content.res->getType();
+            if (!ftype->isInteger () ||
+                !ttype->isInteger () ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
+              return false;
+            } else if (ftype->getSize() > ttype->getSize()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_smaller.format(i));
+              return false;
+            }
 
-          if (!ftype->isInteger ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::IntToPtr));
-            return false;
+            return true;
           }
 
-          else if (ttype->getTypeID() != MiniMC::Model::TypeID::Pointer) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::IntToPtr));
-            return false;
+          else if constexpr (i == InstructionCode::BoolSExt ||
+              i == InstructionCode::BoolZExt) {
+
+            MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied from boolean types to  integer types. ");
+            MiniMC::Support::Localiser must_be_smaller("From type must be smaller that to type for '%1%'");
+
+            auto ftype = content.op1->getType();
+            auto ttype = content.res->getType();
+
+            if (ftype->getTypeID() != MiniMC::Model::TypeID::Bool ||
+                !ttype->isInteger () ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
+              return false;
+            } else if (ftype->getSize() > ttype->getSize()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_smaller.format(i));
+              return false;
+            }
+
+            return true;
           }
 
-          return true;
+          else if constexpr (i == InstructionCode::IntToPtr) {
+            MiniMC::Support::Localiser must_be_integer("'%1%' can only be applied to integer types. ");
+            MiniMC::Support::Localiser must_be_pointer("Return type has to be pointer for '%1%'");
 
-        }
-	
-        else if constexpr (i == InstructionCode::PtrAdd) {
-          MiniMC::Support::Localiser must_be_integer("'%2%' has to be an integer for '%1%'. ");
-          MiniMC::Support::Localiser must_be_same_type("'value and skipeSize must be same type '%1%'. ");
+            auto ftype = content.op1->getType();
+            auto ttype = content.res->getType();
 
-          MiniMC::Support::Localiser must_be_pointer("Return type has to be pointer for '%1%'");
-          MiniMC::Support::Localiser base_must_be_pointer("Base  has to be pointer for '%1%'");
-	  
-	  
-          auto ptr = content.ptr->getType();
-          auto skip = content.skipsize->getType();
-          auto value = content.nbSkips->getType();
-          auto result = content.res->getType();
-	  
-          if (result->getTypeID() != MiniMC::Model::TypeID::Pointer &&
-	      result->getTypeID() != MiniMC::Model::TypeID::Pointer32
-	      ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::PtrAdd));
-            return false;
-          } else if (!skip->isInteger () ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::PtrAdd, "SkipSize"));
-            return false;
-          } else if (!value->isInteger ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::PtrAdd, "Value"));
-            return false;
-          } else if (value != skip) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(MiniMC::Model::InstructionCode::PtrAdd, "Value"));
-            return false;
+            if (!ftype->isInteger ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::IntToPtr));
+              return false;
+            }
+
+            else if (ttype->getTypeID() != MiniMC::Model::TypeID::Pointer) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::IntToPtr));
+              return false;
+            }
+
+            return true;
+
           }
 
-          else if (ptr->getTypeID() != MiniMC::Model::TypeID::Pointer &&
-		   ptr->getTypeID() != MiniMC::Model::TypeID::Pointer32
-		   ) {
-            mess.message<MiniMC::Support::Severity::Error>(base_must_be_pointer.format(MiniMC::Model::InstructionCode::PtrAdd));
-            return false;
+          else if constexpr (i == InstructionCode::PtrAdd) {
+            MiniMC::Support::Localiser must_be_integer("'%2%' has to be an integer for '%1%'. ");
+            MiniMC::Support::Localiser must_be_same_type("'value and skipeSize must be same type '%1%'. ");
+
+            MiniMC::Support::Localiser must_be_pointer("Return type has to be pointer for '%1%'");
+            MiniMC::Support::Localiser base_must_be_pointer("Base  has to be pointer for '%1%'");
+
+
+            auto ptr = content.ptr->getType();
+            auto skip = content.skipsize->getType();
+            auto value = content.nbSkips->getType();
+            auto result = content.res->getType();
+
+            if (result->getTypeID() != MiniMC::Model::TypeID::Pointer &&
+                result->getTypeID() != MiniMC::Model::TypeID::Pointer32
+               ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::PtrAdd));
+              return false;
+            } else if (!skip->isInteger () ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::PtrAdd, "SkipSize"));
+              return false;
+            } else if (!value->isInteger ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::PtrAdd, "Value"));
+              return false;
+            } else if (value != skip) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(MiniMC::Model::InstructionCode::PtrAdd, "Value"));
+              return false;
+            }
+
+            else if (ptr->getTypeID() != MiniMC::Model::TypeID::Pointer &&
+                ptr->getTypeID() != MiniMC::Model::TypeID::Pointer32
+                ) {
+              mess.message<MiniMC::Support::Severity::Error>(base_must_be_pointer.format(MiniMC::Model::InstructionCode::PtrAdd));
+              return false;
+            }
+
+            if (ptr->getTypeID () != result->getTypeID ()) {
+              mess.message<MiniMC::Support::Severity::Error>("Must be ssame pointer type");
+              return false;
+
+            }
+
+            return true;
           }
 
-	  if (ptr->getTypeID () != result->getTypeID ()) {
-	    mess.message<MiniMC::Support::Severity::Error>("Must be ssame pointer type");
-            return false;
-          
-	  }
-	  
-          return true;
-        }
+          else if constexpr (i == InstructionCode::PtrToInt) {
+            MiniMC::Support::Localiser must_be_pointer("'%1%' can only be applied to pointer types. ");
+            MiniMC::Support::Localiser must_be_integer("Return type has to be integer for '%1%'");
 
-        else if constexpr (i == InstructionCode::PtrToInt) {
-          MiniMC::Support::Localiser must_be_pointer("'%1%' can only be applied to pointer types. ");
-          MiniMC::Support::Localiser must_be_integer("Return type has to be integer for '%1%'");
-	  
-          auto ftype = content.op1->getType();
-          auto ttype = content.res->getType();
-          if (ftype->getTypeID() != MiniMC::Model::TypeID::Pointer &&
- 	      ftype->getTypeID() != MiniMC::Model::TypeID::Pointer32
-	      ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::PtrToInt));
-            return false;
+            auto ftype = content.op1->getType();
+            auto ttype = content.res->getType();
+            if (ftype->getTypeID() != MiniMC::Model::TypeID::Pointer &&
+                ftype->getTypeID() != MiniMC::Model::TypeID::Pointer32
+               ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::PtrToInt));
+              return false;
+            }
+
+            else if (!ttype->isInteger ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::PtrToInt));
+              return false;
+            }
+
+            return true;
           }
 
-          else if (!ttype->isInteger ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::PtrToInt));
-            return false;
+          else if constexpr (i == InstructionCode::Store) {
+            MiniMC::Support::Localiser must_be_pointer("'%1%' can only store to pointer types. ");
+
+            auto addr = content.addr->getType();
+            if (addr->getTypeID() != MiniMC::Model::TypeID::Pointer &&
+                addr->getTypeID() != MiniMC::Model::TypeID::Pointer32
+               ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::Store));
+              return false;
+            }
+
+            return true;
           }
 
-          return true;
-        }
-        
-        else if constexpr (i == InstructionCode::Store) {
-          MiniMC::Support::Localiser must_be_pointer("'%1%' can only store to pointer types. ");
 
-          auto addr = content.addr->getType();
-          if (addr->getTypeID() != MiniMC::Model::TypeID::Pointer &&
-	      addr->getTypeID() != MiniMC::Model::TypeID::Pointer32
-	      ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::Store));
-            return false;
+          else if constexpr (i == InstructionCode::Load) {
+            MiniMC::Support::Localiser must_be_pointer("'%1%' can only load from pointer types. ");
+            MiniMC::Support::Localiser must_be_numeric("'%1%' can only load int, float, or doubles. ");
+
+            auto addr = content.addr->getType();
+            if (addr->getTypeID() != MiniMC::Model::TypeID::Pointer &&
+                addr->getTypeID() != MiniMC::Model::TypeID::Pointer32) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::Load));
+              return false;
+            }
+
+            if (!(content.res->getType()->isInteger () ||
+                  content.res->getType()->isFloat () ||
+                  content.res->getType()->isDouble ())) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_numeric.format(MiniMC::Model::InstructionCode::Load));
+              return false;
+            }
+
+            return true;
           }
 
-          return true;
-        }
-	
-	
-        else if constexpr (i == InstructionCode::Load) {
-          MiniMC::Support::Localiser must_be_pointer("'%1%' can only load from pointer types. ");
-          MiniMC::Support::Localiser must_be_integer("'%1%' can only load integers. ");
-
-          auto addr = content.addr->getType();
-          if (addr->getTypeID() != MiniMC::Model::TypeID::Pointer &&
-	      addr->getTypeID() != MiniMC::Model::TypeID::Pointer32) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_pointer.format(MiniMC::Model::InstructionCode::Load));
-            return false;
+          else if constexpr (i == InstructionCode::Skip) {
+            return true;
           }
 
-          if (!content.res->getType()->isInteger () ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(MiniMC::Model::InstructionCode::Load));
-            return false;
+
+          else if constexpr (i == InstructionCode::Skip) {
+            return true;
           }
 
-          return true;
-        }
+          else if constexpr (i == InstructionCode::Call) {
+            auto func = content.function;
+            if (!func->isConstant()) {
+              MiniMC::Support::Localiser must_be_constant("'%1%' can only use constant function pointers. ");
+              mess.message<MiniMC::Support::Severity::Error>(must_be_constant.format(i));
+              return false;
+            }
 
-        else if constexpr (i == InstructionCode::Skip) {
-          return true;
-        }
+            else {
+              auto constant = std::static_pointer_cast<MiniMC::Model::TConstant<pointer_t>>(func);
+              auto ptr = (*constant).template getValue (); //MiniMC::Support::CastToPtr (constant->getValue());
+              bool is_func = prgm.functionExists(MiniMC::getFunctionId(ptr));
+              MiniMC::Support::Localiser function_not_exists("Call references unexisting function: '%1%'");
+              if (!is_func) {
+                mess.message<MiniMC::Support::Severity::Error>(function_not_exists.format(MiniMC::getFunctionId(ptr)));
+                return false;
+              }
 
-	
-        else if constexpr (i == InstructionCode::Skip) {
-          return true;
-        }
-	
-        else if constexpr (i == InstructionCode::Call) {
-          auto func = content.function;
-          if (!func->isConstant()) {
-            MiniMC::Support::Localiser must_be_constant("'%1%' can only use constant function pointers. ");
-            mess.message<MiniMC::Support::Severity::Error>(must_be_constant.format(i));
-            return false;
+              auto func = prgm.getFunction(MiniMC::getFunctionId(ptr));
+              if (func->getParameters().size() != content.params.size()) {
+                mess.message<MiniMC::Support::Severity::Error>("Inconsistent number of parameters between call and function prototype");
+                return false;
+              }
+
+              auto nbParams = content.params.size();
+              auto it = func->getParameters().begin();
+
+              for (size_t j = 0; j < nbParams; j++, ++it) {
+                auto form_type = (*it)->getType();
+                auto act_type = content.params.at(j)->getType();
+                if (form_type != act_type) {
+                  mess.message<MiniMC::Support::Severity::Error>("Formal and actual parameters do not match typewise");
+                  return false;
+                }
+              }
+
+              if (content.res) {
+                auto resType = content.res->getType();
+                if (resType != func->getReturnType()) {
+                  mess.message<MiniMC::Support::Severity::Error>("Result and return type of functions must match.");
+                  return false;
+                }
+              }
+            }
+
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::Assign) {
+            MiniMC::Support::Localiser must_be_same_type("Result and assignee must be same type for '%1%' ");
+            auto valT = content.op1->getType();
+            auto resT = content.res->getType();
+            if (valT != resT) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(i));
+              return false;
+            }
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::Ret) {
+            if (tt != content.value->getType()) {
+              MiniMC::Support::Localiser must_be_same_type("Return value of '%1% must be the same as the function");
+
+              mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(MiniMC::Model::InstructionCode::Ret));
+              return false;
+            }
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::RetVoid) {
+            if (tt->getTypeID() != MiniMC::Model::TypeID::Void) {
+              MiniMC::Support::Localiser must_be_same_type("Return type of function with '%1%' must be void  ");
+              mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(MiniMC::Model::InstructionCode::RetVoid));
+              return false;
+            }
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::NonDet) {
+            auto type = inst.getOps<i>().res->getType();
+            MiniMC::Support::Localiser must_be_numeric("'%1% must return Int, floats, or doubles");
+            if (!type->isInteger ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_numeric.format(i));
+              return false;
+            }
+
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::Assert ||
+              i == InstructionCode::Assume ||
+              i == InstructionCode::NegAssume) {
+            MiniMC::Support::Localiser must_be_bool("'%1%' must take boolean or integer as input. ");
+
+            auto type = content.expr->getType();
+            if (type->getTypeID() != MiniMC::Model::TypeID::Bool &&
+                !type->isInteger () ) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_bool.format(i));
+              return false;
+            }
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::ExtractValue ||
+              i == InstructionCode::InsertValue
+              ) {
+            MiniMC::Support::Localiser warning("TypeCheck not fully implemented for '%1%'");
+            MiniMC::Support::Localiser must_be_aggregate("%2% must be aggregate '%1%'");
+            MiniMC::Support::Localiser must_be_integer("offset must be integer '%1%'");
+
+            if (!content.offset->getType ()->isInteger ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
+              return false;
+            }
+
+            if (!content.aggregate->getType ()->isAggregate ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_aggregate.format(i,"aggregate"));
+              return false;
+            }
+
+            if constexpr (i == InstructionCode::InsertValue) {
+              if (!content.res->getType ()->isAggregate ()) {
+                mess.message<MiniMC::Support::Severity::Error>(must_be_aggregate.format(i,"res"));
+                return false;
+              }
+            }
+
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::BitCast) {
+            MiniMC::Support::Localiser warning("TypeCheck not fully implemented for '%1%'");
+            mess.message<MiniMC::Support::Severity::Warning> (warning.format(i));
+            return true;
+          }
+
+          else if constexpr (i == InstructionCode::Uniform) {
+            MiniMC::Support::Localiser must_be_same_type("Result and assignee must be same type for '%1%' ");
+            MiniMC::Support::Localiser must_be_integer("Result must be integer for '%1%' ");
+
+            if (!MiniMC::Model::hasSameTypeID({content.res->getType(),
+                  content.max->getType(),
+                  content.min->getType()})) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(i));
+              return false;
+            }
+
+            if (!content.res->getType()->isInteger ()) {
+              mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
+              return false;
+            }
+
+            return true;
           }
 
           else {
-            auto constant = std::static_pointer_cast<MiniMC::Model::TConstant<pointer_t>>(func);
-            auto ptr = (*constant).template getValue (); //MiniMC::Support::CastToPtr (constant->getValue());
-            bool is_func = prgm.functionExists(MiniMC::getFunctionId(ptr));
-            MiniMC::Support::Localiser function_not_exists("Call references unexisting function: '%1%'");
-            if (!is_func) {
-              mess.message<MiniMC::Support::Severity::Error>(function_not_exists.format(MiniMC::getFunctionId(ptr)));
-              return false;
-            }
-
-            auto func = prgm.getFunction(MiniMC::getFunctionId(ptr));
-            if (func->getParameters().size() != content.params.size()) {
-              mess.message<MiniMC::Support::Severity::Error>("Inconsistent number of parameters between call and function prototype");
-              return false;
-            }
-
-            auto nbParams = content.params.size();
-            auto it = func->getParameters().begin();
-
-            for (size_t j = 0; j < nbParams; j++, ++it) {
-              auto form_type = (*it)->getType();
-              auto act_type = content.params.at(j)->getType();
-              if (form_type != act_type) {
-                mess.message<MiniMC::Support::Severity::Error>("Formal and actual parameters do not match typewise");
-                return false;
-              }
-            }
-
-            if (content.res) {
-              auto resType = content.res->getType();
-              if (resType != func->getReturnType()) {
-                mess.message<MiniMC::Support::Severity::Error>("Result and return type of functions must match.");
-                return false;
-              }
-            }
+            []<bool b = false>() { static_assert(b && "cannot type check instruction"); }
+            ();
           }
-
-          return true;
         }
-
-        else if constexpr (i == InstructionCode::Assign) {
-          MiniMC::Support::Localiser must_be_same_type("Result and assignee must be same type for '%1%' ");
-          auto valT = content.op1->getType();
-          auto resT = content.res->getType();
-          if (valT != resT) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(i));
-            return false;
-          }
-          return true;
-        }
-
-        else if constexpr (i == InstructionCode::Ret) {
-          if (tt != content.value->getType()) {
-            MiniMC::Support::Localiser must_be_same_type("Return value of '%1% must be the same as the function");
-
-            mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(MiniMC::Model::InstructionCode::Ret));
-            return false;
-          }
-          return true;
-        }
-
-        else if constexpr (i == InstructionCode::RetVoid) {
-          if (tt->getTypeID() != MiniMC::Model::TypeID::Void) {
-            MiniMC::Support::Localiser must_be_same_type("Return type of function with '%1%' must be void  ");
-            mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(MiniMC::Model::InstructionCode::RetVoid));
-            return false;
-          }
-          return true;
-        }
-
-        else if constexpr (i == InstructionCode::NonDet) {
-          auto type = inst.getOps<i>().res->getType();
-          MiniMC::Support::Localiser must_be_integer("'%1% must return Integers");
-          if (!type->isInteger ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
-            return false;
-          }
-
-          return true;
-        }
-
-        else if constexpr (i == InstructionCode::Assert ||
-                           i == InstructionCode::Assume ||
-                           i == InstructionCode::NegAssume) {
-          MiniMC::Support::Localiser must_be_bool("'%1%' must take boolean or integer as input. ");
-
-          auto type = content.expr->getType();
-          if (type->getTypeID() != MiniMC::Model::TypeID::Bool &&
-              !type->isInteger () ) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_bool.format(i));
-            return false;
-          }
-          return true;
-        }
-
-	else if constexpr (i == InstructionCode::ExtractValue ||
-                           i == InstructionCode::InsertValue
-			   ) {
-          MiniMC::Support::Localiser warning("TypeCheck not fully implemented for '%1%'");
-	  MiniMC::Support::Localiser must_be_aggregate("%2% must be aggregate '%1%'");
-	  MiniMC::Support::Localiser must_be_integer("offset must be integer '%1%'");
-	  
-	  if (!content.offset->getType ()->isInteger ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
-            return false;
-          }
-
-	  if (!content.aggregate->getType ()->isAggregate ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_aggregate.format(i,"aggregate"));
-            return false;
-          }
-
-	  if constexpr (i == InstructionCode::InsertValue) {
-	    if (!content.res->getType ()->isAggregate ()) {
-	      mess.message<MiniMC::Support::Severity::Error>(must_be_aggregate.format(i,"res"));
-	      return false;
-	    }
-	  }
-	  
-	  return true;
-        }
-        
-        else if constexpr (i == InstructionCode::BitCast) {
-          MiniMC::Support::Localiser warning("TypeCheck not fully implemented for '%1%'");
-	  mess.message<MiniMC::Support::Severity::Warning> (warning.format(i));
-          return true;
-        }
-
-        else if constexpr (i == InstructionCode::Uniform) {
-          MiniMC::Support::Localiser must_be_same_type("Result and assignee must be same type for '%1%' ");
-          MiniMC::Support::Localiser must_be_integer("Result must be integer for '%1%' ");
-
-          if (!MiniMC::Model::hasSameTypeID({content.res->getType(),
-                                             content.max->getType(),
-                                             content.min->getType()})) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_same_type.format(i));
-            return false;
-          }
-
-          if (!content.res->getType()->isInteger ()) {
-            mess.message<MiniMC::Support::Severity::Error>(must_be_integer.format(i));
-            return false;
-          }
-
-          return true;
-        }
-
-        else {
-          []<bool b = false>() { static_assert(b && "cannot type check instruction"); }
-          ();
-        }
-      }
 
       bool TypeChecker::run(MiniMC::Model::Program& prgm) {
         bool res = true;
         for (auto& F : prgm.getFunctions()) {
           for (auto& E : F->getCFA().getEdges()) {
-	    auto& instrkeeper = E->getInstructions ();
+            auto& instrkeeper = E->getInstructions ();
             if (instrkeeper) {
               for (auto& I : instrkeeper) {
 
                 switch (I.getOpcode()) {
 #define X(OP)                                                                                      \
-  case MiniMC::Model::InstructionCode::OP:                                                         \
-    if (!doCheck<MiniMC::Model::InstructionCode::OP>(I,  F->getReturnType(), prgm)) { \
-      res = false;                                                                                 \
-    }                                                                                              \
-    break;
+                  case MiniMC::Model::InstructionCode::OP:                                                         \
+                                                                                                                   if (!doCheck<MiniMC::Model::InstructionCode::OP>(I,  F->getReturnType(), prgm)) { \
+                                                                                                                     res = false;                                                                                 \
+                                                                                                                   }                                                                                              \
+                  break;
                   OPERATIONS
                 }
               }

--- a/libs/model/src/types.cpp
+++ b/libs/model/src/types.cpp
@@ -6,111 +6,115 @@
 namespace MiniMC {
   namespace Model {
     class IntegerType : public Type {
-    public:
-      IntegerType(size_t b,TypeID id) : Type(id),
-                              bytes(b) {}
-      std::size_t getSize() const override { return bytes; }
-      std::ostream& output(std::ostream& os) const override  {
-	std::ostream copy (os.rdbuf());
-	copy << std::dec << std::noshowbase <<  "Int" << bytes * 8;
-	return os;
-      }
-      bool isInteger () const override {return true;}
-    protected:
-      virtual bool innerEq(const Type& t) override {
-        return bytes == static_cast<const IntegerType&>(t).bytes;
-      }
+      public:
+        IntegerType(size_t b,TypeID id) : Type(id),
+        bytes(b) {}
+        std::size_t getSize() const override { return bytes; }
+        std::ostream& output(std::ostream& os) const override  {
+          std::ostream copy (os.rdbuf());
+          copy << std::dec << std::noshowbase <<  "Int" << bytes * 8;
+          return os;
+        }
+        bool isInteger () const override {return true;}
+      protected:
+        virtual bool innerEq(const Type& t) override {
+          return bytes == static_cast<const IntegerType&>(t).bytes;
+        }
 
-    private:
-      size_t bytes;
+      private:
+        size_t bytes;
     };
 
     class FloatType : public Type {
-    public:
-      FloatType() : Type(TypeID::Float) {}
-      std::size_t getSize() const { return 4; }
-       std::ostream& output(std::ostream& os) const { return os << "Float"; }
-      bool innerEq(const Type& ) { return true; }
+      public:
+        FloatType() : Type(TypeID::Float) {}
+        std::size_t getSize() const override { return 4; }
+        std::ostream& output(std::ostream& os) const override { return os << "Float"; }
+        bool isFloat () const override {return true;}
+      protected:
+        bool innerEq(const Type& ) override { return true; }
     };
 
     class DoubleType : public Type {
-    public:
-      DoubleType() : Type(TypeID::Double) {}
-      std::size_t getSize() const { return 8; }
-      std::ostream& output(std::ostream& os) const { return os << "Double"; }
-      bool innerEq(const Type& ) { return false; }
+      public:
+        DoubleType() : Type(TypeID::Double) {}
+        std::size_t getSize() const override { return 8; }
+        std::ostream& output(std::ostream& os) const override { return os << "Double"; }
+        bool isDouble () const override {return true;}
+      protected:
+        bool innerEq(const Type& ) override { return true; }
     };
 
 #ifdef MINIMC32
     class PointerType : public Type {
-    public:
-      PointerType() : Type(TypeID::Pointer32) {}
-      std::size_t getSize() const { return sizeof(MiniMC::pointer32_t); }
-      std::ostream& output(std::ostream& os) const { return os << "Pointer32"; }
-      bool innerEq(const Type& ) { return true; }
+      public:
+        PointerType() : Type(TypeID::Pointer32) {}
+        std::size_t getSize() const { return sizeof(MiniMC::pointer32_t); }
+        std::ostream& output(std::ostream& os) const { return os << "Pointer32"; }
+        bool innerEq(const Type& ) { return true; }
     };
 #else
     class PointerType : public Type {
-    public:
-      PointerType() : Type(TypeID::Pointer) {}
-      std::size_t getSize() const { return sizeof(MiniMC::pointer_t); }
-      std::ostream& output(std::ostream& os) const { return os << "Pointer"; }
-      bool innerEq(const Type& ) { return true; }
+      public:
+        PointerType() : Type(TypeID::Pointer) {}
+        std::size_t getSize() const { return sizeof(MiniMC::pointer_t); }
+        std::ostream& output(std::ostream& os) const { return os << "Pointer"; }
+        bool innerEq(const Type& ) { return true; }
     };
 #endif
-    
-class BoolType : public Type {
-    public:
-      BoolType() : Type(TypeID::Bool) {}
-      std::size_t getSize() const { return 1; }
-      std::ostream& output(std::ostream& os) const { return os << "Bool"; }
-      bool innerEq(const Type&) { return true; }
+
+    class BoolType : public Type {
+      public:
+        BoolType() : Type(TypeID::Bool) {}
+        std::size_t getSize() const { return 1; }
+        std::ostream& output(std::ostream& os) const { return os << "Bool"; }
+        bool innerEq(const Type&) { return true; }
     };
 
     class VoidType : public Type {
-    public:
-      VoidType() : Type(TypeID::Void) {}
-      std::size_t getSize() const { return 0; }
-      std::ostream& output(std::ostream& os) const { return os << "Void"; }
-      bool innerEq(const Type&) { return true; }
+      public:
+        VoidType() : Type(TypeID::Void) {}
+        std::size_t getSize() const { return 0; }
+        std::ostream& output(std::ostream& os) const { return os << "Void"; }
+        bool innerEq(const Type&) { return true; }
     };
 
     class AggregateType : public Type {
-    public:
-      AggregateType(TypeID h, size_t size) : Type(h), size(size) {}
-      std::size_t getSize() const { return size; }
-      std::ostream& output(std::ostream& os) const { 
-	std::ostream copy (os.rdbuf());  
-	copy << "Aggr" << std::dec << std::noshowbase << size;
-	return os;
-      }
-      bool innerEq(const Type& t) { return size == static_cast<const AggregateType&>(t).size; }
-      bool isAggregate () const override {return true;}
-      
-    private:
-      std::size_t size;
+      public:
+        AggregateType(TypeID h, size_t size) : Type(h), size(size) {}
+        std::size_t getSize() const { return size; }
+        std::ostream& output(std::ostream& os) const { 
+          std::ostream copy (os.rdbuf());  
+          copy << "Aggr" << std::dec << std::noshowbase << size;
+          return os;
+        }
+        bool innerEq(const Type& t) { return size == static_cast<const AggregateType&>(t).size; }
+        bool isAggregate () const override {return true;}
+
+      private:
+        std::size_t size;
     };
 
     class StructType : public AggregateType {
-    public:
-      StructType(std::size_t size) : AggregateType(TypeID::Struct, size) {}
+      public:
+        StructType(std::size_t size) : AggregateType(TypeID::Struct, size) {}
     };
 
     class ArrayType : public AggregateType {
-    public:
-      ArrayType(std::size_t size) : AggregateType(TypeID::Array, size) {}
+      public:
+        ArrayType(std::size_t size) : AggregateType(TypeID::Array, size) {}
     };
 
     struct TypeFactory64::Inner {
       Inner() : vt(new VoidType()),
-                dt(new DoubleType()),
-                ft(new FloatType()),
-                bt(new BoolType()),
-                pt(new PointerType()),
-                i8(new IntegerType(1,TypeID::I8)),
-                i16(new IntegerType(2,TypeID::I16)),
-                i32(new IntegerType(4,TypeID::I32)),
-                i64(new IntegerType(8,TypeID::I64)) {}
+      dt(new DoubleType()),
+      ft(new FloatType()),
+      bt(new BoolType()),
+      pt(new PointerType()),
+      i8(new IntegerType(1,TypeID::I8)),
+      i16(new IntegerType(2,TypeID::I16)),
+      i32(new IntegerType(4,TypeID::I32)),
+      i64(new IntegerType(8,TypeID::I64)) {}
       Type_ptr vt;
       Type_ptr dt;
       Type_ptr ft;

--- a/libs/model/src/variables.cpp
+++ b/libs/model/src/variables.cpp
@@ -20,26 +20,45 @@ namespace MiniMC {
       switch (ty) {
         case MiniMC::Model::TypeID::Bool:
           retval.reset(new Bool(static_cast<MiniMC::BV8>(val)));
-	  type = typefact->makeBoolType ();
-	  break;
+          type = typefact->makeBoolType ();
+          break;
         case MiniMC::Model::TypeID::I8:
           retval.reset(new MiniMC::Model::TConstant<MiniMC::BV8>(static_cast<MiniMC::BV8>(val)));
-	  type = typefact->makeIntegerType (8);
-	  break;
+          type = typefact->makeIntegerType (8);
+          break;
         case MiniMC::Model::TypeID::I16:
           retval.reset(new MiniMC::Model::TConstant<MiniMC::BV16>(static_cast<MiniMC::BV16>(val)));
-	  type = typefact->makeIntegerType (16);
-	  break;
+          type = typefact->makeIntegerType (16);
+          break;
         case MiniMC::Model::TypeID::I32:
           retval.reset(new MiniMC::Model::TConstant<MiniMC::BV32>(static_cast<MiniMC::BV32>(val)));
-	  type = typefact->makeIntegerType (32);
-	  break;
+          type = typefact->makeIntegerType (32);
+          break;
         case MiniMC::Model::TypeID::I64:
           retval.reset(new MiniMC::Model::TConstant<MiniMC::BV64>(static_cast<MiniMC::BV64>(val)));
-	  type = typefact->makeIntegerType (64);
-	  break;
-      default:
-	throw MiniMC::Support::Exception("Error");
+          type = typefact->makeIntegerType (64);
+          break;
+        default:
+          throw MiniMC::Support::Exception("Error");
+      }
+      retval->setType(type);
+      return retval;
+    }
+    
+    const Value_ptr ConstantFactory64::makeFloatConstant(MiniMC::BV64 val, TypeID ty) {
+      Value_ptr retval;
+      Type_ptr type;
+      switch (ty) {
+        case MiniMC::Model::TypeID::Float:
+          retval.reset(new MiniMC::Model::TConstant<MiniMC::BV32>(static_cast<MiniMC::BV32>(val)));
+          type = typefact->makeFloatType ();
+          break;
+        case MiniMC::Model::TypeID::Double:
+          retval.reset(new MiniMC::Model::TConstant<MiniMC::BV64>(static_cast<MiniMC::BV64>(val)));
+          type = typefact->makeDoubleType ();
+          break;
+        default:
+          throw MiniMC::Support::Exception("Error");
       }
       retval->setType(type);
       return retval;
@@ -49,16 +68,16 @@ namespace MiniMC {
     const Value_ptr ConstantFactory64::makeFunctionPointer(MiniMC::func_t id) {
       auto ptrtype = typefact->makePointerType ();
       Value_ptr v;
-      
+
       if (ptrtype->getSize () == 4) {
-	v.reset (new MiniMC::Model::Pointer32 (MiniMC::pointer32_t::makeFunctionPointer (id)));  
+        v.reset (new MiniMC::Model::Pointer32 (MiniMC::pointer32_t::makeFunctionPointer (id)));  
       }
 
       else {
-	v.reset (new MiniMC::Model::Pointer (MiniMC::pointer64_t::makeFunctionPointer (id)));  
+        v.reset (new MiniMC::Model::Pointer (MiniMC::pointer64_t::makeFunctionPointer (id)));  
       }
-      
-      
+
+
       v->setType (ptrtype);
       return v;
     }
@@ -68,68 +87,68 @@ namespace MiniMC {
       Value_ptr v;
 
       if (ptrtype->getSize () == 4) {
-	v.reset (new MiniMC::Model::Pointer32 (MiniMC::pointer32_t::makeLocationPointer (id,lid)));  
+        v.reset (new MiniMC::Model::Pointer32 (MiniMC::pointer32_t::makeLocationPointer (id,lid)));  
       }
 
       else {
-	v.reset (new MiniMC::Model::Pointer (MiniMC::pointer64_t::makeLocationPointer (id,lid)));  
+        v.reset (new MiniMC::Model::Pointer (MiniMC::pointer64_t::makeLocationPointer (id,lid)));  
       }
-      
+
 
       v->setType (ptrtype);
       return v;
     }
-    
-    
-    
+
+
+
     const Value_ptr ConstantFactory64::makeHeapPointer(MiniMC::base_t base) {
       auto ptrtype = typefact->makePointerType ();
       Value_ptr v;
 
       if (ptrtype->getSize () == 4) {
-	v.reset (new MiniMC::Model::Pointer32 (MiniMC::pointer32_t::makeHeapPointer (base,0)));  
+        v.reset (new MiniMC::Model::Pointer32 (MiniMC::pointer32_t::makeHeapPointer (base,0)));  
       }
 
       else {
-	v.reset (new MiniMC::Model::Pointer (MiniMC::pointer64_t::makeHeapPointer (base,0)));  
+        v.reset (new MiniMC::Model::Pointer (MiniMC::pointer64_t::makeHeapPointer (base,0)));  
       }
       v->setType (ptrtype);
       return v;
     }
-    
+
     const Value_ptr ConstantFactory64::makeUndef(TypeID ty,std::size_t size) {
       Value_ptr val(new MiniMC::Model::Undef());
       Type_ptr type;
 
       switch (ty) {
-      case TypeID::I8:
-	type = typefact->makeIntegerType (8);
-	break;
-      case TypeID::I16:
-	type = typefact->makeIntegerType (16);
-	break;
-      case TypeID::I32:
-	type = typefact->makeIntegerType (32);
-	break;
-      case TypeID::I64:
-	type = typefact->makeIntegerType (64);
-	break;
-      case TypeID::Bool:
-	type = typefact->makeBoolType ();
-	break;
-      case TypeID::Pointer:
-	type = typefact->makePointerType ();
-	break;
-      case TypeID::Struct:
-	type = typefact->makeStructType (size);
-	break;
-      case TypeID::Array:
-	type = typefact->makeArrayType (size);
-	break;
-      default:
-	throw MiniMC::Support::Exception ("Errror");
+        case TypeID::I8:
+          type = typefact->makeIntegerType (8);
+          break;
+        case TypeID::I16:
+          type = typefact->makeIntegerType (16);
+          break;
+        case TypeID::I32:
+          type = typefact->makeIntegerType (32);
+          break;
+        case TypeID::I64:
+          type = typefact->makeIntegerType (64);
+          break;
+        case TypeID::Bool:
+          type = typefact->makeBoolType ();
+          break;
+        case TypeID::Pointer:
+          type = typefact->makePointerType ();
+          break;
+        case TypeID::Struct:
+          type = typefact->makeStructType (size);
+          break;
+        case TypeID::Array:
+          type = typefact->makeArrayType (size);
+          break;
+        default:
+          throw MiniMC::Support::Exception ("Errror");
       }
-      
+
       val->setType(type);
       return val;
     }
@@ -172,32 +191,32 @@ namespace MiniMC {
             break;
           case MiniMC::Model::TypeID::Struct:
           case MiniMC::Model::TypeID::Array: {
-            auto aggr = std::static_pointer_cast<MiniMC::Model::AggregateConstant>(c);
-            out = std::copy(aggr->begin(), aggr->end(), out);
-	    break;
-	  }
+                                               auto aggr = std::static_pointer_cast<MiniMC::Model::AggregateConstant>(c);
+                                               out = std::copy(aggr->begin(), aggr->end(), out);
+                                               break;
+                                             }
           default:
-            throw MiniMC::Support::Exception("Unknown how to convert to aggregate");
+                                             throw MiniMC::Support::Exception("Unknown how to convert to aggregate");
         }
       }
       Type_ptr type;
       if (isArray)
-	type = typefact->makeArrayType (size);
+        type = typefact->makeArrayType (size);
       else
-	type = typefact->makeStructType (size);
-      
+        type = typefact->makeStructType (size);
+
       Value_ptr v(new MiniMC::Model::AggregateConstant(reinterpret_cast<MiniMC::BV8*>(data.get()), size));
       v->setType (type);
       return v;
-  }
+    }
 
     Undef::Undef() : Constant(ValueInfo<Undef>::type_t()) {}
     Register::Register(const Symbol& name, RegisterDescr* owner) : Value(ValueInfo<Register>::type_t()),
-                                                                        name(name), owner(owner) {}
+    name(name), owner(owner) {}
 
     AggregateConstant::AggregateConstant(MiniMC::BV8* data, std::size_t s) : Constant(ValueInfo<AggregateConstant>::type_t()),
-                                                                                 value(new MiniMC::BV8[s]),
-                                                                                 size(s) {
+    value(new MiniMC::BV8[s]),
+    size(s) {
       std::copy(data, data + s, value.get());
     }
 


### PR DESCRIPTION
- clang-format file
- Format check
- Deleted format workflow
- Removed the nuisance of having SMT setup being a global setting
- Formatting
- formatting and some clean up (deleting unused parameters
- Gradual move towards a more elegant interface for creating instructions
- - Removed all the builder classes (calling instead the instruction creator directly) - Next step is to remove the Helpers
- missing file
- - Switched away from helper constructions
- - Squashed some warnings,
- - Added support for InsertValue/ExtractValue in Concrete. -
- Made heaplayout structure -- allowing "pre-allocating" memory and constructing "pre-instantiation" pointer. This has the benefit of completely removing the global register from the system (since they are just constants). It also removes the need for the ugly NonCompileConstants (i.e. those that depended on the allocating of globals)
- Deleted the debug output of the modified LLVM code
- Quashed warning
- Removed dependence on internal structure of InstructionStream
- Making "semantic" hooks out from instructioncode to the actual instructions. This moves the semantics to some extend away from the concrete CPA...allowing to reuse them in the symbolic CPA (when things are concrete)
- ff
- Quashed warnings
- Work on transferring interpretation to decidated  VM rather than implementing it constantly for all CPAs
- VM added... still integrated though
- fdh
- New VM
- Made all test cases pass
- Moving operations into external objects
- - Aggregate for new pathformula
- - Missing files - Dedicated TypeID for I8,I16,I32,I64
- More missing files
- 
- - CallStack for pathformula - Disable the "delay" feature of simulation manager
- Added LLVM to dependency sub-folder Disabled CI for now
- CI
- Disable CI
- Missing
- Enable CI again
- Hackish way to get cmake to link static libraries to shared
- Fixing the python binding
- Copy of programs
- Fixing the python binding
- missing file
- fsdfhk
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- Cleanup (deleted unneeded files
- Work in progress
- Encapculating reachability in own object
- Missing file
- Missing file
- Guard against including pybind11 unless actually needing it
- Started separating instantiation of analysis state from Program.
- Fairly big changes to message setup
- Clearer ownership of VariableStacks.
- 
- Moving away from shared_ptr for CFA
- Gives ownership of CFAs to the functions (no more shared_ptr)
- Renaming of functions and class (CFA-CFG, VariableStackDesc -> RegisterDescr)
- Visitor pattern for values
- removed gsl
- - Preparing separate storage mechanisms - Streamlining the hashing a bit (as a result of debugging)
- Moved stack allocations out from heap allocations
- memory added to pathformula
- - Slight cleanup - Graceful fail
- Template similar things between pathformula and concrete CPAS
- - Put most of the logic of setting up function parameters into the VM - New HashCombiner (uses the xxhash) rather than the old hash_combiner function
- Deleted unused file
- deleted unused cmake_finds
- 
- - Moved the create entry point logic into loaders, - LLVM loader now sets up its own stack
- Removed - Alloca - ExtendObj - Free
- Make sure values are always given a type when constructed by the ConstantFactory
- Proper output for Aggregates in new MiniMC model format
- Moved reference of registerdescr onto the LocationInfo. This way we have easy access to active registers in a given context.....
- Started making a new QueryExprions setup for CPAs
- Split states into datapart and cfa part
- Started adding model generation for pathformula (still some way to go)
- Evaluation of values from PathFormulaVM
- Compile fixes for gcc12
- Deleted hard to maintain code
- reimplemented expand nodetdet
- - Making default values when initially creating register - Give warning when asking for NonDet values in Concrete analysis
- Trying to tidy up llvm loader
- Typecheking for InsertValue and ExtractValue
- - Sqaushed a few warnings - removed unused code -
- Upgraded to LLVM 14
- - Removed ugle getSize checks on types
- THrow Error when failing to load program
- h
- Proper readout of pointers from CVC4
- - removed unused cmd-line options   - should be re-added somehow though
- missing file
- Moved smtlib out of git submodule
- Proper value genration for Booleans
- - Started preparation for different pointer rep (64 and 32) - Still some problems
- - Compile-time switch between 32bit pointers and 64bit pointers. - In future it should be a runtime switch
- Removed base64
- Templated the representatins
- Operations on Pointer32
- Most setup for 32 pointers working..although there is an error making the variant valueles
- Fixed error where pointers were casted "wrongly
- Disabled CI
- Removed gsl
- CI/CD
- CI/CD fix - hopefully
- Update build.yml
- Added .gitignore
- First PoC of the Interpreter
- Intitial terminal gui added
- Printing of Variables
- Removed guihelper
- Added functionality for look ahead
- Added boolcasts and asservialotelocation to the miniinterpreter
- Moved the interpreter into bin, and added it as a command
- include cvc4 dev in workflow
- Better print
- CANT COMPILE: first attempt to introduce task in the interpreter
- test?
- Outline for the TaskFactory design
- Working CLI
- Added Bookmark functionality
- Interpreter skips noinstructionedges
- First iteration of "static" commands
- Added option of path - without functionality tho
- POC of path as argument - intp.path
- Formatting
- overall structure for the parser/lexer
- First working POC
- implemented statemap
- Edges can now be printed and a step needs an egde index
- changes to cmakelist
- Folder structure for minimc-parser
- Nothing works
- Typo in tokens
- New structure in parrser
- Removed double whitespaces
- Removed double whitespaces
- The overall structure for the parser and lexer done
- First working POC of minimc Parser
- Parser exception added and ini files updated
- Closes #7
- Squashed warnings
- Added MMC test aswell as some cases
- Added Tokens as x-macroes
- Making it easier to make fully qualified names
- Change the operations so it depedent on the ones in instruction.hpp
- - Rename - A few tests for new symbols structure
- - Changed the symbol representation to be a list of strings
- - Major rework of repository... - Libraries now have their cmake project and evertyhing related (e.g. source files, include files, tests ) to it should be confined in that project
- - (better) Packaging  into zip files - deleted unused headers
- - moved smt into own sub-project
- - Pacaking (into zip) - Updated build to package as well
- added support for map of twosigned symbols such as "##" or "->"
- Added Minor changes to the syntax and added "Aggr" type
- MiniMC parser updated such it handle Symbols instead of string names
- - Program copier actually copies entry points, - MiniMC throws error when tasks are added from cmdline - Allow running MiniMC without tasks
- Support for comments
- The parser now handles hex/digits up to a usigned long instead of int
- Fixed prefixes in MiniMC Parser
- Annotation for AssertViolated
- X-macroes is now a part of the parser for better or worse
- Addresses #13 - Changed loader selection to use the name of loaders rather than indcices into the Loader-registrar. -
- Added correct indentation to code
- Added pre-commit configuration to ignored files
- Added compile_commands.json generation to CMakeLists.txt
- - Throw Exception when trying to store Booleans and Aggregates - Copy intialisers in program copying --- deleted unneeded assert
- Adding storing of Aggregates to concrete memory model
- Moved entry points into only being part of LLVM loader.
- Removed last remnants of old entry-point creation code
- Reenabling inlining and unrolling of loops
- Added arm directory
- Deleted old Guard stuff
- Initial float and double impl
- Iåpdate workflow
- Updated workflow
- Added float support
